### PR TITLE
dependabot で GitHub Actions で使ってる action を更新できるようにする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
       day: "friday"
       time: "18:00"
       timezone: "Asia/Tokyo"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "18:00"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
#8 でちゃんと dependabot が動くことはわかってるので、GitHub Actions の更新もやってもらいます。