### PR TITLE
dependabotはテストが通れば自動マージする

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -10,19 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Merge a PR
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
これまでパッチバージョンの時だけ自動マージできるようにしてたけど、自分で見てる過去のPRはほぼ全部マージしてるし
プロダクションならともかく、自分しかメンテしてない小さなアプリではそんながちがちにする理由ないから
テストが通ればマージとする。

もし破壊的変更があったとしてもテストしてる部分についてはほとんど壊れないと思っていいはずだし(つまりカバレッジと書いたテストが重要部分だったか次第。。。)。