### PR TITLE
GitHub Actions ワークフローに最小限の permissions を追加

### DIFF
--- a/.github/workflows/auto-approve-my-PR.yaml
+++ b/.github/workflows/auto-approve-my-PR.yaml
@@ -7,6 +7,9 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  pull-requests: write
+
 jobs:
   self-approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -4,6 +4,9 @@ run-name: CI triggered by ${{ github.actor }}
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- go-ci.yml: contents read のみ（lint/test 用）
- auto-approve-my-PR.yaml: pull-requests write のみ ワークフロー権限制限に関するセキュリティ通知への対応

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow YAML-only change that reduces default token privileges; minimal risk beyond misconfigured permissions causing CI/auto-approve failures.
> 
> **Overview**
> Restricts GitHub Actions workflow token permissions to the minimum required.
> 
> `auto-approve-my-PR.yaml` now explicitly requests `pull-requests: write` so it can approve PRs, and `go-ci.yml` now requests only `contents: read` for checkout/build steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcff6508dfc04872723ea2a6c3d9e879c4eae936. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->