### PR TITLE
Jimiko go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ deploy:
 	@gcloud functions deploy jimiko-slack-2nd-gen --entry-point Slack \
 		--gen2 --trigger-http --region=asia-northeast1 \
 		--env-vars-file .env.yaml \
-		--runtime=go122 \
+		--runtime=go125 \
 		--set-secrets 'SLACK_SIGINING_SECRET=jimiko-slack-signing:latest'

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kimikimi714/jimiko
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.1
+toolchain go1.25.7
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.9.2


### PR DESCRIPTION
Upgrade Go version to 1.25.0 and update Cloud Functions runtime to modernize the project.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-33f997c1-93bb-55ef-bbfb-a3513bd4746c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33f997c1-93bb-55ef-bbfb-a3513bd4746c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/deploy configuration-only changes; main risk is runtime/toolchain compatibility issues when deploying or compiling under Go 1.25.
> 
> **Overview**
> Upgrades the project to **Go 1.25** by updating `go.mod` (`go 1.25.0` and `toolchain go1.25.7`) and switches the Cloud Functions deploy target runtime in `Makefile` from `go122` to `go125`.
> 
> No application logic changes; this PR primarily modernizes the build/deployment environment to align local toolchain and GCP runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f336dfb50c1fc559f715df204c7a321210f477e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->